### PR TITLE
Update tarballs.py

### DIFF
--- a/kolla_dockerhub_pusher/tarballs.py
+++ b/kolla_dockerhub_pusher/tarballs.py
@@ -37,7 +37,7 @@ class TarFile(object):
     def extract(self):
         click.echo("Extracting to " + self.local_path + "registry")
         tar = tarfile.open(self.local_path + self.fname, "r:gz")
-        tar.extractall(path=self.local_path + "registry", numeric_owner=True)
+        tar.extractall(path=self.local_path + "registry")
         tar.close()
 
     def rename_lokolla(self):


### PR DESCRIPTION
removed numeric_owner=true; Python 2.7 doesn't support this feature.
https://docs.python.org/2.7/library/tarfile.html#tarfile.TarFile.extractall
https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall